### PR TITLE
Bk table definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ rel/example_project
 *~
 src/riak_ql_lexer.erl
 src/riak_ql_parser.erl
+_build
+rebar.lock

--- a/include/riak_kv_ddl.hrl
+++ b/include/riak_kv_ddl.hrl
@@ -1,0 +1,57 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_ddl: defines records used in the data description language
+%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-record(riak_field_v1, {
+	  name     = <<>>  :: list(),
+	  position         :: pos_integer(),
+	  type             :: field_type(),
+	  optional = false :: boolean()
+	 }).
+
+-type field_type()         :: simple_field_type() | complex_field_type().
+-type simple_field_type()  :: binary | integer | float | timestamp | boolean | set.
+-type complex_field_type() :: {map, [#riak_field_v1{}]} | any.
+
+-record(param_v1, {
+	  name :: string()
+	 }).
+
+-record(hash_fn_v1, {
+	  mod       :: atom(),
+	  fn        :: atom(),
+	  args = [] :: [#param_v1{} | any()]
+	 }).
+
+-record(partition_key_v1, {
+	  ast = [] :: [#hash_fn_v1{} | #param_v1{}]
+	 }).
+
+-record(local_key_v1, {
+	  ast = [] :: [#hash_fn_v1{} | #param_v1{}]
+	 }).
+
+-record(ddl_v1, {
+	  bucket             :: binary(),
+	  fields        = [] :: [#riak_field_v1{}],
+	  partition_key      :: #partition_key_v1{},
+	  local_key          :: #local_key_v1{}
+	 }).

--- a/include/riak_kv_ddl.hrl
+++ b/include/riak_kv_ddl.hrl
@@ -20,38 +20,43 @@
 %%
 %% -------------------------------------------------------------------
 
+-ifndef(RIAK_KV_DDL).
+-define(RIAK_KV_DDL, true).
+
 -record(riak_field_v1, {
-	  name     = <<>>  :: list(),
-	  position         :: pos_integer(),
-	  type             :: field_type(),
-	  optional = false :: boolean()
-	 }).
+          name     = <<>>  :: list(),
+          position         :: pos_integer(),
+          type             :: field_type(),
+          optional = false :: boolean()
+         }).
 
 -type field_type()         :: simple_field_type() | complex_field_type().
 -type simple_field_type()  :: binary | integer | float | timestamp | boolean | set.
 -type complex_field_type() :: {map, [#riak_field_v1{}]} | any.
 
 -record(param_v1, {
-	  name :: string()
-	 }).
+          name :: string()
+         }).
 
 -record(hash_fn_v1, {
-	  mod       :: atom(),
-	  fn        :: atom(),
-	  args = [] :: [#param_v1{} | any()]
-	 }).
+          mod       :: atom(),
+          fn        :: atom(),
+          args = [] :: [#param_v1{} | any()]
+         }).
 
 -record(partition_key_v1, {
-	  ast = [] :: [#hash_fn_v1{} | #param_v1{}]
-	 }).
+          ast = [] :: [#hash_fn_v1{} | #param_v1{}]
+         }).
 
 -record(local_key_v1, {
-	  ast = [] :: [#hash_fn_v1{} | #param_v1{}]
-	 }).
+          ast = [] :: [#hash_fn_v1{} | #param_v1{}]
+         }).
 
 -record(ddl_v1, {
-	  bucket             :: binary(),
-	  fields        = [] :: [#riak_field_v1{}],
-	  partition_key      :: #partition_key_v1{},
-	  local_key          :: #local_key_v1{}
-	 }).
+          bucket             :: binary(),
+          fields        = [] :: [#riak_field_v1{}],
+          partition_key      :: #partition_key_v1{},
+          local_key          :: #local_key_v1{}
+         }).
+
+-endif.

--- a/include/riak_kv_ddl.hrl
+++ b/include/riak_kv_ddl.hrl
@@ -20,9 +20,6 @@
 %%
 %% -------------------------------------------------------------------
 
--ifndef(RIAK_KV_DDL).
--define(RIAK_KV_DDL, true).
-
 -record(riak_field_v1, {
           name     = <<>>  :: list(),
           position         :: pos_integer(),
@@ -58,5 +55,3 @@
           partition_key      :: #partition_key_v1{},
           local_key          :: #local_key_v1{}
          }).
-
--endif.

--- a/priv/keyword_generator.rb
+++ b/priv/keyword_generator.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require 'csv'
+require 'pp'
+
+ERLANG_RESERVED = %w{and of or}
+
+csv_filename =
+  ARGV[0] ||
+  File.join(File.dirname(__FILE__), '..', 'src', 'riak_ql_keywords.csv')
+
+keywords = Hash.new
+
+CSV.foreach(csv_filename) do |row|
+  keyword = row.first
+  kw_name = keyword.gsub(/\s+/,'_').upcase
+  keywords[kw_name] = keyword
+end
+
+# definitions
+# SELECT  = (S|s)(E|e)(L|l)(E|e)(C|c)(T|t)
+keywords.each do |kw_name, keyword|
+  kw_regexp =
+    keyword.chars.map do |c|
+    next '\s' if c =~ /\s/
+    next c unless c =~ /[a-zA-Z]/
+    "(#{c.upcase}|#{c.downcase})"
+  end.join
+
+  puts "#{kw_name} = #{kw_regexp}"
+end
+
+puts
+
+# rules
+# {SELECT}  : {token, {select,  TokenChars}}.
+keywords.each do |kw_name, keyword|
+  kw_token = kw_name.downcase
+  if ERLANG_RESERVED.include? kw_token
+    kw_token += '_'
+  end
+  puts "{#{kw_name}} : {token, {#{kw_token}, TokenChars}}."
+end

--- a/src/riak_ql.erl
+++ b/src/riak_ql.erl
@@ -15,17 +15,15 @@
 -file("src/riak_ql.xrl", 86).
 
 -include_lib("eunit/include/eunit.hrl").
-		
+
 -export([
-	 lex/1
-	]).
+         lex/1
+        ]).
 
 -compile(export_all).
 
--include("riak_ql.xrl.tests").
-
 lex(String) -> {ok, Toks, 1} = string(String),
-	       Toks.
+               Toks.
 
 strip_date(Date) ->
     Date2 = string:strip(Date, both, $'), %'

--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -69,6 +69,14 @@ keywords_3b_test_() ->
                ],
     ?_assertEqual(Expected, Got).
 
+keywords_create_test_() ->
+    Got = riak_ql_lexer:get_tokens("create table not null partition key"),
+    Expected = [
+                {create_table, "create table"},
+                {not_null, "not null"},
+                {partition_key, "partition key"}],
+    ?_assertEqual(Expected, Got).
+
 words_containing_keywords_test_() ->
     Got = riak_ql_lexer:get_tokens("error or horror and handy andy"),
     Expected = [

--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -89,6 +89,15 @@ words_containing_keywords_test_() ->
                ],
     ?_assertEqual(Expected, Got).
 
+words_containing_digits_test_() ->
+    Got = riak_ql_lexer:get_tokens("sha512 sha 512"),
+    Expected = [
+                {chars, "sha512"},
+                {chars, "sha"},
+                {int, 512}
+               ],
+    ?_assertEqual(Expected, Got).
+
 nums_test_() ->
     Got = riak_ql_lexer:get_tokens("1 -2 2.0 -2.0 3.3e+3 -3.3e-3"),
     Expected = [

--- a/src/riak_ql.xrl.tests
+++ b/src/riak_ql.xrl.tests
@@ -90,7 +90,7 @@ words_containing_keywords_test_() ->
     ?_assertEqual(Expected, Got).
 
 words_containing_digits_test_() ->
-    Got = riak_ql_lexer:get_tokens("sha512 sha 512"),
+    Got = riak_ql_lexer:get_tokens("'sha512' sha 512"),
     Expected = [
                 {chars, "sha512"},
                 {chars, "sha"},

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -208,7 +208,7 @@ select_where_15_test() ->
 create_simple_test_() ->
     ?_t("create table temperatures " ++
             "(time timestamp not null, " ++
-            "temperature_k float not null, " ++
+            "temperature_k float, " ++
             "partition key (time))",
         #ddl_v1{
            bucket = <<"temperatures">>,
@@ -222,7 +222,7 @@ create_simple_test_() ->
                         name = "temperature_k",
                         position = 1,
                         type = float,
-                        optional = false}],
+                        optional = true}],
            partition_key = #partition_key_v1{
                               ast = [#param_v1{
                                         name = "time"

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -215,12 +215,12 @@ create_simple_test_() ->
            fields = [
                      #riak_field_v1{
                         name = "time",
-                        position = 0,
+                        position = 1,
                         type = timestamp,
                         optional = false},
                      #riak_field_v1{
                         name = "temperature_k",
-                        position = 1,
+                        position = 2,
                         type = float,
                         optional = true}],
            partition_key = #partition_key_v1{
@@ -241,17 +241,17 @@ create_local_key_test_() ->
            fields = [
                      #riak_field_v1{
                         name = "time",
-                        position = 0,
+                        position = 1,
                         type = timestamp,
                         optional = false},
                      #riak_field_v1{
                         name = "temperature_k",
-                        position = 1,
+                        position = 2,
                         type = float,
                         optional = true},
                      #riak_field_v1{
                         name = "user_id",
-                        position = 2,
+                        position = 3,
                         type = varchar,
                         optional = false}],
            partition_key = #partition_key_v1{
@@ -275,12 +275,12 @@ create_composite_key_test_() ->
            fields = [
                      #riak_field_v1{
                         name = "time",
-                        position = 0,
+                        position = 1,
                         type = timestamp,
                         optional = false},
                      #riak_field_v1{
                         name = "user_id",
-                        position = 1,
+                        position = 2,
                         type = varchar,
                         optional = false}],
            partition_key = #partition_key_v1{
@@ -310,12 +310,12 @@ create_modfun_key_test_() ->
            fields = [
                      #riak_field_v1{
                         name = "time",
-                        position = 0,
+                        position = 1,
                         type = timestamp,
                         optional = false},
                      #riak_field_v1{
                         name = "user_id",
-                        position = 1,
+                        position = 2,
                         type = varchar,
                         optional = false}],
            partition_key = #partition_key_v1{
@@ -347,12 +347,12 @@ create_no_key_test_() ->
            fields = [
                      #riak_field_v1{
                         name = "time",
-                        position = 0,
+                        position = 1,
                         type = timestamp,
                         optional = false},
                      #riak_field_v1{
                         name = "temperature_k",
-                        position = 1,
+                        position = 2,
                         type = float,
                         optional = true}]
           }).

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -229,6 +229,41 @@ create_simple_test_() ->
                                        }]}
           }).
 
+create_local_key_test_() ->
+    ?_t("create table temperatures " ++
+            "(time timestamp not null, " ++
+            "temperature_k float, " ++
+            "user_id varchar not null, " ++
+            "partition key (time), " ++
+            "local key (user_id))",
+        #ddl_v1{
+           bucket = <<"temperatures">>,
+           fields = [
+                     #riak_field_v1{
+                        name = "time",
+                        position = 0,
+                        type = timestamp,
+                        optional = false},
+                     #riak_field_v1{
+                        name = "temperature_k",
+                        position = 1,
+                        type = float,
+                        optional = true},
+                     #riak_field_v1{
+                        name = "user_id",
+                        position = 2,
+                        type = varchar,
+                        optional = false}],
+           partition_key = #partition_key_v1{
+                              ast = [#param_v1{
+                                        name = "time"
+                                       }]},
+           local_key = #local_key_v1{
+                          ast = [#param_v1{
+                                    name = "user_id"
+                                    }]}
+          }).
+
 % select count(type) from events group by time(10m);
 
 % select count(type) from events group by time(10m), type;

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -299,6 +299,35 @@ create_composite_key_test_() ->
                                     }]}
           }).
 
+create_modfun_key_test_() ->
+    ?_t("create table temperatures " ++
+            "(time timestamp not null, " ++
+            "user_id varchar not null, " ++
+            "partition key (time, modfun(crypto, hash, atom(sha512))))",
+        #ddl_v1{
+           bucket = <<"temperatures">>,
+           fields = [
+                     #riak_field_v1{
+                        name = "time",
+                        position = 0,
+                        type = timestamp,
+                        optional = false},
+                     #riak_field_v1{
+                        name = "user_id",
+                        position = 1,
+                        type = varchar,
+                        optional = false}],
+           partition_key = #partition_key_v1{
+                              ast = [#param_v1{
+                                        name = "time"
+                                       },
+                                     #hash_fn_v1{
+                                        mod = crypto,
+                                        fn = hash,
+                                        args = [sha512]
+                                       }]}
+          }).
+
 % select count(type) from events group by time(10m);
 
 % select count(type) from events group by time(10m), type;

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -1,6 +1,8 @@
 %% -*- erlang -*-
 -include_lib("eunit/include/eunit.hrl").
 
+-include("riak_kv_ddl.hrl").
+
 -define(_t(String, Expected),
         ?_test(
            ?assertEqual({ok, Expected},
@@ -202,6 +204,30 @@ select_where_15_test() ->
                           }
                          }
               }).
+
+create_simple_test_() ->
+    ?_t("create table temperatures " ++
+            "(time timestamp not null, " ++
+            "temperature_k float not null, " ++
+            "partition key (time))",
+        #ddl_v1{
+           bucket = <<"temperatures">>,
+           fields = [
+                     #riak_field_v1{
+                        name = "time",
+                        position = 0,
+                        type = timestamp,
+                        optional = false},
+                     #riak_field_v1{
+                        name = "temperature_k",
+                        position = 1,
+                        type = float,
+                        optional = false}],
+           partition_key = #partition_key_v1{
+                              ast = [#param_v1{
+                                        name = "time"
+                                       }]}
+          }).
 
 % select count(type) from events group by time(10m);
 

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -303,7 +303,8 @@ create_modfun_key_test_() ->
     ?_t("create table temperatures " ++
             "(time timestamp not null, " ++
             "user_id varchar not null, " ++
-            "partition key (time, modfun(crypto, hash, atom('sha512'))))",
+            "partition key (time, modfun(crypto, hash, atom('sha512'))), " ++
+            "local key (modfun(crypto, hash, atom(ripemd)), time))",
         #ddl_v1{
            bucket = <<"temperatures">>,
            fields = [
@@ -325,7 +326,16 @@ create_modfun_key_test_() ->
                                         mod = crypto,
                                         fn = hash,
                                         args = [sha512]
-                                       }]}
+                                       }]},
+           local_key = #local_key_v1{
+                          ast = [#hash_fn_v1{
+                                    mod = crypto,
+                                    fn = hash,
+                                    args = [ripemd]
+                                    },
+                                #param_v1{
+                                  name = "time"
+                                  }]}
           }).
 
 % select count(type) from events group by time(10m);

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -338,6 +338,25 @@ create_modfun_key_test_() ->
                                   }]}
           }).
 
+create_no_key_test_() ->
+    ?_t("create table temperatures " ++
+            "(time timestamp not null, " ++
+            "temperature_k float)",
+        #ddl_v1{
+           bucket = <<"temperatures">>,
+           fields = [
+                     #riak_field_v1{
+                        name = "time",
+                        position = 0,
+                        type = timestamp,
+                        optional = false},
+                     #riak_field_v1{
+                        name = "temperature_k",
+                        position = 1,
+                        type = float,
+                        optional = true}]
+          }).
+
 % select count(type) from events group by time(10m);
 
 % select count(type) from events group by time(10m), type;

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -264,6 +264,41 @@ create_local_key_test_() ->
                                     }]}
           }).
 
+create_composite_key_test_() ->
+    ?_t("create table temperatures " ++
+            "(time timestamp not null, " ++
+            "user_id varchar not null, " ++
+            "partition key (time, user_id), " ++
+            "local key (time, user_id))",
+        #ddl_v1{
+           bucket = <<"temperatures">>,
+           fields = [
+                     #riak_field_v1{
+                        name = "time",
+                        position = 0,
+                        type = timestamp,
+                        optional = false},
+                     #riak_field_v1{
+                        name = "user_id",
+                        position = 1,
+                        type = varchar,
+                        optional = false}],
+           partition_key = #partition_key_v1{
+                              ast = [#param_v1{
+                                        name = "time"
+                                       },
+                                    #param_v1{
+                                      name = "user_id"
+                                      }]},
+           local_key = #local_key_v1{
+                          ast = [#param_v1{
+                                    name = "time"
+                                    },
+                                 #param_v1{
+                                    name = "user_id"
+                                    }]}
+          }).
+
 % select count(type) from events group by time(10m);
 
 % select count(type) from events group by time(10m), type;

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -303,7 +303,7 @@ create_modfun_key_test_() ->
     ?_t("create table temperatures " ++
             "(time timestamp not null, " ++
             "user_id varchar not null, " ++
-            "partition key (time, modfun(crypto, hash, atom(sha512))))",
+            "partition key (time, modfun(crypto, hash, atom('sha512'))))",
         #ddl_v1{
            bucket = <<"temperatures">>,
            fields = [

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -1,7 +1,6 @@
 %% -*- erlang -*-
 -include_lib("eunit/include/eunit.hrl").
 
--include("riak_kv_ddl.hrl").
 
 -define(_t(String, Expected),
         ?_test(

--- a/src/riak_ql.yrl.tests
+++ b/src/riak_ql.yrl.tests
@@ -252,7 +252,7 @@ create_local_key_test_() ->
                      #riak_field_v1{
                         name = "user_id",
                         position = 3,
-                        type = varchar,
+                        type = binary,
                         optional = false}],
            partition_key = #partition_key_v1{
                               ast = [#param_v1{
@@ -281,7 +281,7 @@ create_composite_key_test_() ->
                      #riak_field_v1{
                         name = "user_id",
                         position = 2,
-                        type = varchar,
+                        type = binary,
                         optional = false}],
            partition_key = #partition_key_v1{
                               ast = [#param_v1{
@@ -316,7 +316,7 @@ create_modfun_key_test_() ->
                      #riak_field_v1{
                         name = "user_id",
                         position = 2,
-                        type = varchar,
+                        type = binary,
                         optional = false}],
            partition_key = #partition_key_v1{
                               ast = [#param_v1{

--- a/src/riak_ql_keywords.csv
+++ b/src/riak_ql_keywords.csv
@@ -1,5 +1,6 @@
 and
 as
+atom
 create table
 delete
 drop
@@ -13,6 +14,7 @@ limit
 local
 local key
 merge
+modfun
 not null
 of
 on commit

--- a/src/riak_ql_keywords.csv
+++ b/src/riak_ql_keywords.csv
@@ -3,6 +3,7 @@ as
 create
 delete
 drop
+float
 from
 global
 groupby
@@ -11,9 +12,11 @@ join
 limit
 local
 merge
+not null
 of
 on commit
 or
+partition key
 preserve
 rows
 select

--- a/src/riak_ql_keywords.csv
+++ b/src/riak_ql_keywords.csv
@@ -11,6 +11,7 @@ inner
 join
 limit
 local
+local key
 merge
 not null
 of
@@ -23,5 +24,6 @@ select
 system versioning
 temporary
 timestamp
+varchar
 where
 with

--- a/src/riak_ql_keywords.csv
+++ b/src/riak_ql_keywords.csv
@@ -1,6 +1,6 @@
 and
 as
-create
+create table
 delete
 drop
 float
@@ -21,7 +21,6 @@ preserve
 rows
 select
 system versioning
-table
 temporary
 where
 with

--- a/src/riak_ql_keywords.csv
+++ b/src/riak_ql_keywords.csv
@@ -1,0 +1,24 @@
+and
+as
+create
+delete
+drop
+from
+global
+groupby
+inner
+join
+limit
+local
+merge
+of
+on commit
+or
+preserve
+rows
+select
+system versioning
+table
+temporary
+where
+with

--- a/src/riak_ql_keywords.csv
+++ b/src/riak_ql_keywords.csv
@@ -22,5 +22,6 @@ rows
 select
 system versioning
 temporary
+timestamp
 where
 with

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -5,19 +5,32 @@
 
 Definitions.
 
-SELECT  = (S|s)(E|e)(L|l)(E|e)(C|c)(T|t)
-FROM    = (F|f)(R|r)(O|o)(M|m)
-LIMIT   = (L|l)(I|i)(M|m)(I|i)(T|t)
-WHERE   = (W|w)(H|h)(E|e)(R|r)(E|e)
-AND     = (A|a)(N|n)(D|d)
-OR      = (O|o)(R|r)
-DELETE  = (D|d)(E|e)(L|l)(E|e)(T|t)(E|e)
-DROP    = (D|d)(R|r)(O|o)(P|p)
+AND = (A|a)(N|n)(D|d)
+AS = (A|a)(S|s)
+CREATE_TABLE = (C|c)(R|r)(E|e)(A|a)(T|t)(E|e)\s(T|t)(A|a)(B|b)(L|l)(E|e)
+DELETE = (D|d)(E|e)(L|l)(E|e)(T|t)(E|e)
+DROP = (D|d)(R|r)(O|o)(P|p)
+FLOAT = (F|f)(L|l)(O|o)(A|a)(T|t)
+FROM = (F|f)(R|r)(O|o)(M|m)
+GLOBAL = (G|g)(L|l)(O|o)(B|b)(A|a)(L|l)
 GROUPBY = (G|g)(R|r)(O|o)(U|u)(P|p)(B|b)(Y|y)
-MERGE   = (M|m)(E|e)(R|r)(G|g)(E|e)
-INNER   = (I|i)(N|n)(N|n)(E|e)(R|r)
-JOIN    = (J|j)(O|o)(I|i)(N|n)
-AS      = (A|a)(S|s)
+INNER = (I|i)(N|n)(N|n)(E|e)(R|r)
+JOIN = (J|j)(O|o)(I|i)(N|n)
+LIMIT = (L|l)(I|i)(M|m)(I|i)(T|t)
+LOCAL = (L|l)(O|o)(C|c)(A|a)(L|l)
+MERGE = (M|m)(E|e)(R|r)(G|g)(E|e)
+NOT_NULL = (N|n)(O|o)(T|t)\s(N|n)(U|u)(L|l)(L|l)
+OF = (O|o)(F|f)
+ON_COMMIT = (O|o)(N|n)\s(C|c)(O|o)(M|m)(M|m)(I|i)(T|t)
+OR = (O|o)(R|r)
+PARTITION_KEY = (P|p)(A|a)(R|r)(T|t)(I|i)(T|t)(I|i)(O|o)(N|n)\s(K|k)(E|e)(Y|y)
+PRESERVE = (P|p)(R|r)(E|e)(S|s)(E|e)(R|r)(V|v)(E|e)
+ROWS = (R|r)(O|o)(W|w)(S|s)
+SELECT = (S|s)(E|e)(L|l)(E|e)(C|c)(T|t)
+SYSTEM_VERSIONING = (S|s)(Y|y)(S|s)(T|t)(E|e)(M|m)\s(V|v)(E|e)(R|r)(S|s)(I|i)(O|o)(N|n)(I|i)(N|n)(G|g)
+TEMPORARY = (T|t)(E|e)(M|m)(P|p)(O|o)(R|r)(A|a)(R|r)(Y|y)
+WHERE = (W|w)(H|h)(E|e)(R|r)(E|e)
+WITH = (W|w)(I|i)(T|t)(H|h)
 
 DATETIME = ('[0-9a-zA-Z\s:\-\.]*')
 
@@ -50,19 +63,32 @@ COMMA = (,)
 
 Rules.
 
-{SELECT}  : {token, {select,  TokenChars}}.
-{FROM}    : {token, {from,    TokenChars}}.
-{LIMIT}   : {token, {limit,   TokenChars}}.
-{WHERE}   : {token, {where,   TokenChars}}.
-{AND}     : {token, {and_,    TokenChars}}.
-{OR}      : {token, {or_,     TokenChars}}.
-{DELETE}  : {token, {delete,  TokenChars}}.
-{DROP}    : {token, {drop,    TokenChars}}.
+{AND} : {token, {and_, TokenChars}}.
+{AS} : {token, {as, TokenChars}}.
+{CREATE_TABLE} : {token, {create_table, TokenChars}}.
+{DELETE} : {token, {delete, TokenChars}}.
+{DROP} : {token, {drop, TokenChars}}.
+{FLOAT} : {token, {float, TokenChars}}.
+{FROM} : {token, {from, TokenChars}}.
+{GLOBAL} : {token, {global, TokenChars}}.
 {GROUPBY} : {token, {groupby, TokenChars}}.
-{MERGE}   : {token, {merge,   TokenChars}}.
-{INNER}   : {token, {inner,   TokenChars}}.
-{JOIN}    : {token, {join,    TokenChars}}.
-{AS}      : {token, {as,      TokenChars}}.
+{INNER} : {token, {inner, TokenChars}}.
+{JOIN} : {token, {join, TokenChars}}.
+{LIMIT} : {token, {limit, TokenChars}}.
+{LOCAL} : {token, {local, TokenChars}}.
+{MERGE} : {token, {merge, TokenChars}}.
+{NOT_NULL} : {token, {not_null, TokenChars}}.
+{OF} : {token, {of_, TokenChars}}.
+{ON_COMMIT} : {token, {on_commit, TokenChars}}.
+{OR} : {token, {or_, TokenChars}}.
+{PARTITION_KEY} : {token, {partition_key, TokenChars}}.
+{PRESERVE} : {token, {preserve, TokenChars}}.
+{ROWS} : {token, {rows, TokenChars}}.
+{SELECT} : {token, {select, TokenChars}}.
+{SYSTEM_VERSIONING} : {token, {system_versioning, TokenChars}}.
+{TEMPORARY} : {token, {temporary, TokenChars}}.
+{WHERE} : {token, {where, TokenChars}}.
+{WITH} : {token, {with, TokenChars}}.
 
 {INT}      : {token, {int,   list_to_integer(TokenChars)}}.
 {FLOATDEC} : {token, {float, list_to_float(TokenChars)}}.

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -7,6 +7,7 @@ Definitions.
 
 AND = (A|a)(N|n)(D|d)
 AS = (A|a)(S|s)
+ATOM = (A|a)(T|t)(O|o)(M|m)
 CREATE_TABLE = (C|c)(R|r)(E|e)(A|a)(T|t)(E|e)\s(T|t)(A|a)(B|b)(L|l)(E|e)
 DELETE = (D|d)(E|e)(L|l)(E|e)(T|t)(E|e)
 DROP = (D|d)(R|r)(O|o)(P|p)
@@ -20,6 +21,7 @@ LIMIT = (L|l)(I|i)(M|m)(I|i)(T|t)
 LOCAL = (L|l)(O|o)(C|c)(A|a)(L|l)
 LOCAL_KEY = (L|l)(O|o)(C|c)(A|a)(L|l)\s(K|k)(E|e)(Y|y)
 MERGE = (M|m)(E|e)(R|r)(G|g)(E|e)
+MODFUN = (M|m)(O|o)(D|d)(F|f)(U|u)(N|n)
 NOT_NULL = (N|n)(O|o)(T|t)\s(N|n)(U|u)(L|l)(L|l)
 OF = (O|o)(F|f)
 ON_COMMIT = (O|o)(N|n)\s(C|c)(O|o)(M|m)(M|m)(I|i)(T|t)
@@ -68,6 +70,7 @@ Rules.
 
 {AND} : {token, {and_, TokenChars}}.
 {AS} : {token, {as, TokenChars}}.
+{ATOM} : {token, {atom, TokenChars}}.
 {CREATE_TABLE} : {token, {create_table, TokenChars}}.
 {DELETE} : {token, {delete, TokenChars}}.
 {DROP} : {token, {drop, TokenChars}}.
@@ -81,6 +84,7 @@ Rules.
 {LOCAL} : {token, {local, TokenChars}}.
 {LOCAL_KEY} : {token, {local_key, TokenChars}}.
 {MERGE} : {token, {merge, TokenChars}}.
+{MODFUN} : {token, {modfun, TokenChars}}.
 {NOT_NULL} : {token, {not_null, TokenChars}}.
 {OF} : {token, {of_, TokenChars}}.
 {ON_COMMIT} : {token, {on_commit, TokenChars}}.

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -18,6 +18,7 @@ INNER = (I|i)(N|n)(N|n)(E|e)(R|r)
 JOIN = (J|j)(O|o)(I|i)(N|n)
 LIMIT = (L|l)(I|i)(M|m)(I|i)(T|t)
 LOCAL = (L|l)(O|o)(C|c)(A|a)(L|l)
+LOCAL_KEY = (L|l)(O|o)(C|c)(A|a)(L|l)\s(K|k)(E|e)(Y|y)
 MERGE = (M|m)(E|e)(R|r)(G|g)(E|e)
 NOT_NULL = (N|n)(O|o)(T|t)\s(N|n)(U|u)(L|l)(L|l)
 OF = (O|o)(F|f)
@@ -30,6 +31,7 @@ SELECT = (S|s)(E|e)(L|l)(E|e)(C|c)(T|t)
 SYSTEM_VERSIONING = (S|s)(Y|y)(S|s)(T|t)(E|e)(M|m)\s(V|v)(E|e)(R|r)(S|s)(I|i)(O|o)(N|n)(I|i)(N|n)(G|g)
 TEMPORARY = (T|t)(E|e)(M|m)(P|p)(O|o)(R|r)(A|a)(R|r)(Y|y)
 TIMESTAMP = (T|t)(I|i)(M|m)(E|e)(S|s)(T|t)(A|a)(M|m)(P|p)
+VARCHAR = (V|v)(A|a)(R|r)(C|c)(H|h)(A|a)(R|r)
 WHERE = (W|w)(H|h)(E|e)(R|r)(E|e)
 WITH = (W|w)(I|i)(T|t)(H|h)
 
@@ -77,6 +79,7 @@ Rules.
 {JOIN} : {token, {join, TokenChars}}.
 {LIMIT} : {token, {limit, TokenChars}}.
 {LOCAL} : {token, {local, TokenChars}}.
+{LOCAL_KEY} : {token, {local_key, TokenChars}}.
 {MERGE} : {token, {merge, TokenChars}}.
 {NOT_NULL} : {token, {not_null, TokenChars}}.
 {OF} : {token, {of_, TokenChars}}.
@@ -89,6 +92,7 @@ Rules.
 {SYSTEM_VERSIONING} : {token, {system_versioning, TokenChars}}.
 {TEMPORARY} : {token, {temporary, TokenChars}}.
 {TIMESTAMP} : {token, {timestamp, TokenChars}}.
+{VARCHAR} : {token, {varchar, TokenChars}}.
 {WHERE} : {token, {where, TokenChars}}.
 {WITH} : {token, {with, TokenChars}}.
 

--- a/src/riak_ql_lexer.xrl
+++ b/src/riak_ql_lexer.xrl
@@ -29,6 +29,7 @@ ROWS = (R|r)(O|o)(W|w)(S|s)
 SELECT = (S|s)(E|e)(L|l)(E|e)(C|c)(T|t)
 SYSTEM_VERSIONING = (S|s)(Y|y)(S|s)(T|t)(E|e)(M|m)\s(V|v)(E|e)(R|r)(S|s)(I|i)(O|o)(N|n)(I|i)(N|n)(G|g)
 TEMPORARY = (T|t)(E|e)(M|m)(P|p)(O|o)(R|r)(A|a)(R|r)(Y|y)
+TIMESTAMP = (T|t)(I|i)(M|m)(E|e)(S|s)(T|t)(A|a)(M|m)(P|p)
 WHERE = (W|w)(H|h)(E|e)(R|r)(E|e)
 WITH = (W|w)(I|i)(T|t)(H|h)
 
@@ -87,6 +88,7 @@ Rules.
 {SELECT} : {token, {select, TokenChars}}.
 {SYSTEM_VERSIONING} : {token, {system_versioning, TokenChars}}.
 {TEMPORARY} : {token, {temporary, TokenChars}}.
+{TIMESTAMP} : {token, {timestamp, TokenChars}}.
 {WHERE} : {token, {where, TokenChars}}.
 {WITH} : {token, {with, TokenChars}}.
 

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -299,10 +299,10 @@ make_column({word, FieldName}, {DataType, _}, {not_null, _}) ->
 
 make_key_definition({partition_key, _}, FieldList) ->
     #partition_key_v1{
-       ast = extract_key_field_list(FieldList, [])};
+       ast = lists:reverse(extract_key_field_list(FieldList, []))};
 make_key_definition({local_key, _}, FieldList) ->
     #local_key_v1{
-       ast = extract_key_field_list(FieldList, [])}.
+       ast = lists:reverse(extract_key_field_list(FieldList, []))}.
 
 make_table_element_list(A, {table_element_list, B}) ->
     {table_element_list, [A] ++ B};
@@ -310,7 +310,7 @@ make_table_element_list(A, B) ->
     {table_element_list, [A, B]}.
 
 extract_key_field_list({list, []}, Extracted) ->
-    lists:reverse(Extracted);
+    Extracted;
 extract_key_field_list({list, [Field | Rest]}, Extracted) ->
     [#param_v1{name = Field} |
      extract_key_field_list({list, Rest}, Extracted)].

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -135,6 +135,7 @@ Erlang code.
          }).
 
 -include("riak_ql.yrl.tests").
+-include("riak_kv_ddl.hrl").
 
 process({chars, A}) ->
     {word, A}.

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -358,7 +358,7 @@ make_modfun({list, Elements}) ->
        args = Args}}.
 
 find_fields({table_element_list, Elements}) ->
-    find_fields(0, Elements, []).
+    find_fields(1, Elements, []).
 
 find_fields(_Count, [], Found) ->
     lists:reverse(Found);

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -79,7 +79,6 @@ varchar
 local_key
 modfun
 atom
-binary
 .
 
 Rootsymbol Statement.

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -206,8 +206,8 @@ Erlang code.
           ops     = []
          }).
 
--include("riak_ql.yrl.tests").
 -include("riak_kv_ddl.hrl").
+-include("riak_ql.yrl.tests").
 
 process({chars, A}) ->
     {word, A}.

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -321,11 +321,8 @@ extract_key_field_list({list, [Field | Rest]}, Extracted) ->
 
 make_table_definition({word, BucketName}, Contents) ->
     PartitionKey = find_partition_key(Contents),
-    io:format("partition key ~p~n", [PartitionKey]),
     LocalKey = find_local_key(Contents),
-    io:format("local key ~p~n", [LocalKey]),
     Fields = find_fields(Contents),
-    io:format("fields ~p~n", [Fields]),
     #ddl_v1{
        bucket = list_to_binary(BucketName),
        partition_key = PartitionKey,

--- a/src/riak_ql_parser.yrl
+++ b/src/riak_ql_parser.yrl
@@ -79,6 +79,7 @@ varchar
 local_key
 modfun
 atom
+binary
 .
 
 Rootsymbol Statement.
@@ -294,7 +295,7 @@ make_column({word, FieldName}, {DataType, _}) ->
 make_column({word, FieldName}, {DataType, _}, {not_null, _}) ->
     #riak_field_v1{
        name = FieldName,
-       type = DataType,
+       type = canonicalize_field_type(DataType),
        optional = false}.
 
 make_key_definition({partition_key, _}, FieldList) ->
@@ -367,3 +368,8 @@ find_fields(Count, [Field = #riak_field_v1{} | Rest], Elements) ->
     find_fields(Count + 1, Rest, [PositionedField | Elements]);
 find_fields(Count, [_Head | Rest], Elements) ->
     find_fields(Count, Rest, Elements).
+
+canonicalize_field_type(varchar) ->
+    binary;
+canonicalize_field_type(Type) ->
+    Type.


### PR DESCRIPTION
1. Includes a little Ruby script to generate (but not insert) repetitive case-insensitive keyword blocks
2. Adds keywords for table creation DDL
3. Adds tests for table creation DDL
4. Lexes table creation DDL keywords
5. Parses table creation DDL

The only real caveat is I pull in a duplicate of `riak_kv_ddl.hrl` in order to not have any dependencies. This should probably be changed before integration.